### PR TITLE
Move where to purchase to its own file

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -9,32 +9,6 @@ Panels is a DRM-free comic reader with many features to organize your library an
 
 The first thing you need to get started using Panels is content to read.
 
-## Purchasing content
-
-Panels does not provide any content, all content should be purchased elsewhere.
-
-We do recommend the following sites to purchase DRM-free comics that you can download and import to Panels.
-
-- [Humble bundle](https://www.humblebundle.com/books?partner=panels)
-- [Panelsyndicate](http://panelsyndicate.com/)
-- [3 Worlds / 3 Moons](https://3w3m.substack.com/)
-- [Abstract Studio Comics](https://abstractstudiocomics.com/shop/)
-- [DriveThruComics](https://www.drivethrucomics.com/)
-- [Bad Ink Studios](https://badinkstudios.com/shop/)
-- [GenSeven Comics](https://gen7comics.com/)
-- [Blue Fox Comics](https://bluefoxcomics.com/collections/digital)
-- [eManga](https://emanga.com)
-
-In addition, the following sites offer free, creative commons or public domain comics:
-
-- [Pepper&Carrot](https://www.peppercarrot.com/)
-- [Overwatch Media](https://overwatch.blizzard.com/en-us/media/stories/)
-- [Recursos multimedia de Overwatch](https://overwatch.blizzard.com/es-es/media/stories/)
-- [NASA Moonikin Comic](https://www.nasa.gov/moonikin-comic/)
-- [NASA - First Woman](https://www.nasa.gov/calliefirst/)
-- [Comic Books - Comic Book Plus](https://comicbookplus.com/?cid=1507)
-- [Digital Comic Museum](https://digitalcomicmuseum.com)
-
 ## Importing content into Panels
 
 There are several ways to import your content into Panels, as well as keep it shared & synced between devices.
@@ -50,3 +24,7 @@ Find some more information in [Organize content](/category/organizing-content).
 ## Read your content
 
 In addition to a powerful library, Panels offers an incredible reader with multiple features, from text selection to automatic background color. Visit [Reading content](/category/reading-content) to know more.
+
+## Purchasing content
+
+Panels does not provide any content, all content should be purchased elsewhere. Visit [where to purchase comics](/misc/where-to-purchase.md) for suggestions.

--- a/docs/misc/where-to-purchase.md
+++ b/docs/misc/where-to-purchase.md
@@ -1,0 +1,23 @@
+# Where to purchase comics
+
+We do recommend the following sites to purchase DRM-free comics that you can download and import to Panels.
+
+- [Humble bundle](https://www.humblebundle.com/books?partner=panels)
+- [Panelsyndicate](http://panelsyndicate.com/)
+- [3 Worlds / 3 Moons](https://3w3m.substack.com/)
+- [Abstract Studio Comics](https://abstractstudiocomics.com/shop/)
+- [DriveThruComics](https://www.drivethrucomics.com/)
+- [Bad Ink Studios](https://badinkstudios.com/shop/)
+- [GenSeven Comics](https://gen7comics.com/)
+- [Blue Fox Comics](https://bluefoxcomics.com/collections/digital)
+- [eManga](https://emanga.com)
+
+In addition, the following sites offer **free**, creative commons or public domain comics:
+
+- [Pepper&Carrot](https://www.peppercarrot.com/)
+- [Overwatch Media](https://overwatch.blizzard.com/en-us/media/stories/)
+- [Recursos multimedia de Overwatch](https://overwatch.blizzard.com/es-es/media/stories/)
+- [NASA Moonikin Comic](https://www.nasa.gov/moonikin-comic/)
+- [NASA - First Woman](https://www.nasa.gov/calliefirst/)
+- [Comic Books - Comic Book Plus](https://comicbookplus.com/?cid=1507)
+- [Digital Comic Museum](https://digitalcomicmuseum.com)


### PR DESCRIPTION
Moved all links to purchase/download into its own section.

<img width="1457" alt="Screenshot 2024-05-25 at 06 32 10" src="https://github.com/Produkt/panels-guides/assets/994334/705e37c6-6c52-4bd4-8f8e-0c3c4a88ed25">
