### PR TITLE
Add Algolia search module to our Guides

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -116,6 +116,29 @@ const config = {
         theme: prismThemes.github,
         darkTheme: prismThemes.dracula,
       },
+      algolia: {
+        // The application ID provided by Algolia
+        appId: "5C0JC51MM9",
+
+        // Public API key: it is safe to commit it
+        apiKey: "63d123a26581b9d7e710192b1de4e8d8",
+
+        indexName: "guides",
+
+        // Optional: see doc section below
+        contextualSearch: true,
+
+        // Optional: Algolia search parameters
+        searchParameters: {},
+
+        // Optional: path for search page that enabled by default (`false` to disable it)
+        searchPagePath: "search",
+
+        // Optional: whether the insights feature is enabled or not on Docsearch (`false` by default)
+        insights: false,
+
+        //... other Algolia params
+      },
     }),
 };
 


### PR DESCRIPTION
Recently I asked Algolia to include us in their crawler. 

Docusaurus default template has support for it out of the box, so once Algolia gave us all parameters, it was as simple as adding them to the config.js


https://github.com/user-attachments/assets/15812960-39f6-4bd5-8041-16ea63b1ecde

